### PR TITLE
Update defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## Installation options
-redis_version: 2.8.9
+redis_version: 3.0.6
 redis_install_dir: /opt/redis
 redis_user: redis
 redis_group: "{{ redis_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ redis_as_service: true
 redis_local_facts: true
 
 ## Networking/connection options
-redis_bind: 0.0.0.0
+redis_bind: 127.0.0.1
 redis_port: 6379
 redis_password: false
 redis_tcp_backlog: 511


### PR DESCRIPTION
Update defaults so that the newest stable version is installed, as well as make the defaults more secure by listening only on localhost.